### PR TITLE
feat: implement GraphQL mutation

### DIFF
--- a/src/_lib/__tests__/graphql.test.ts
+++ b/src/_lib/__tests__/graphql.test.ts
@@ -1,0 +1,128 @@
+import { graphqlMutation } from '../graphql';
+
+// Mock the global fetch
+const mockFetch = jest.fn();
+// @ts-ignore - We're mocking the global fetch
+global.fetch = mockFetch;
+
+describe('graphqlMutation', () => {
+    const mockUrl = 'https://test-api.com/graphql';
+    const mockQuery = 'mutation { test }';
+    const mockVariables = { id: 1 };
+    const mockHeaders = { 'Authorization': 'Bearer token' };
+
+    beforeEach(() => {
+        // Clear all mocks before each test
+        jest.clearAllMocks();
+    });
+
+    it('should make a successful GraphQL mutation request', async () => {
+        // Mock successful response
+        const mockData = { test: { id: 1, name: 'Test' } };
+        const mockResponse = {
+            ok: true,
+            status: 200,
+            json: jest.fn().mockResolvedValue({ data: mockData })
+        };
+        mockFetch.mockResolvedValueOnce(mockResponse as any);
+
+        // Call the function
+        const result = await graphqlMutation({
+            url: mockUrl,
+            query: mockQuery,
+            variables: mockVariables,
+            headers: mockHeaders
+        });
+
+        // Verify the fetch was called correctly
+        expect(mockFetch).toHaveBeenCalledWith(mockUrl, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                ...mockHeaders
+            },
+            body: JSON.stringify({
+                query: mockQuery,
+                variables: mockVariables
+            })
+        });
+
+        // Verify the response
+        expect(result).toEqual(mockData);
+    });
+
+    it('should handle GraphQL errors', async () => {
+        // Mock GraphQL error response
+        const mockError = { message: 'Test error' };
+        const mockResponse = {
+            ok: true,
+            status: 200,
+            json: jest.fn().mockResolvedValue({
+                errors: [mockError],
+                data: null
+            })
+        };
+        mockFetch.mockResolvedValueOnce(mockResponse as any);
+
+        // Verify the error is thrown
+        await expect(
+            graphqlMutation({
+                url: mockUrl,
+                query: mockQuery
+            })
+        ).rejects.toThrow('GraphQL Error: Test error');
+    });
+
+    it('should handle HTTP errors', async () => {
+        // Mock HTTP error response
+        const mockResponse = {
+            ok: false,
+            status: 500,
+            statusText: 'Internal Server Error'
+        };
+        mockFetch.mockResolvedValueOnce(mockResponse as any);
+
+        // Verify the error is thrown
+        await expect(
+            graphqlMutation({
+                url: mockUrl,
+                query: mockQuery
+            })
+        ).rejects.toThrow('HTTP error! status: 500');
+    });
+
+    it('should use default URL when not provided', async () => {
+        // Mock successful response
+        const mockData = { test: true };
+        const mockResponse = {
+            ok: true,
+            status: 200,
+            json: jest.fn().mockResolvedValue({ data: mockData })
+        };
+        mockFetch.mockResolvedValueOnce(mockResponse as any);
+
+        // Call without URL
+        await graphqlMutation({
+            query: mockQuery
+        });
+
+        // Should use default URL
+        expect(mockFetch).toHaveBeenCalledWith(
+            'https://api.bukazu.com/graphql',
+            expect.anything()
+        );
+    });
+
+    it('should handle network errors', async () => {
+        // Mock network error
+        mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+        // Verify the error is thrown
+        await expect(
+            graphqlMutation({
+                url: mockUrl,
+                query: mockQuery
+            })
+        ).rejects.toThrow('GraphQL mutation failed: Network error');
+    });
+});

--- a/src/_lib/graphql.ts
+++ b/src/_lib/graphql.ts
@@ -1,0 +1,59 @@
+/**
+ * Interface for the GraphQL mutation options
+ */
+interface GraphQLMutationOptions<TVariables = Record<string, unknown>> {
+    url: string; // GraphQL endpoint URL
+    query: string; // The GraphQL mutation string
+    variables?: TVariables; // Variables for the mutation
+    headers?: Record<string, string>; // Additional headers
+}
+
+/**
+ * Executes a GraphQL mutation using the fetch API
+ * @template TData - The expected response data type
+ * @template TVariables - The variables type for the mutation
+ * @param {GraphQLMutationOptions<TVariables>} options - The mutation options
+ * @returns {Promise<TData>} The response data
+ * @throws {Error} When the request fails or returns errors
+ */
+export async function graphqlMutation<TData = any, TVariables = Record<string, unknown>>(
+    options: GraphQLMutationOptions<TVariables>
+): Promise<TData> {
+    const { url = 'https://api.bukazu.com/graphql', query, variables = {}, headers = {} } = options;
+
+    try {
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                ...headers,
+            },
+            body: JSON.stringify({
+                query,
+                variables,
+            }),
+        });
+
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        const result = await response.json();
+
+        // Check for GraphQL errors
+        if (result.errors) {
+            const errorMessage = result.errors
+                .map((error: { message: string }) => error.message)
+                .join('\n');
+            throw new Error(`GraphQL Error: ${errorMessage}`);
+        }
+
+        return result.data;
+    } catch (error) {
+        // Improve error handling with more context
+        if (error instanceof Error) {
+            throw new Error(`GraphQL mutation failed: ${error.message}`);
+        }
+        throw new Error('An unknown error occurred during the GraphQL mutation');
+    }
+}


### PR DESCRIPTION
This pull request introduces a new utility function, `graphqlMutation`, to handle GraphQL mutation requests and adds comprehensive tests to ensure its reliability. The changes improve the codebase by providing a reusable abstraction for GraphQL mutations and robust error handling.

### New Functionality for GraphQL Mutations:
* Added a `graphqlMutation` function in `src/_lib/graphql.ts` to execute GraphQL mutation requests using the Fetch API. The function includes support for custom headers, default URL handling, and detailed error reporting for both HTTP and GraphQL errors.

### Testing Enhancements:
* Introduced unit tests in `src/_lib/__tests__/graphql.test.ts` to validate the behavior of the `graphqlMutation` function. The tests cover successful requests, GraphQL errors, HTTP errors, default URL usage, and network errors